### PR TITLE
Fix Regex Error

### DIFF
--- a/src/App/backend.cpp
+++ b/src/App/backend.cpp
@@ -90,7 +90,7 @@ void Backend::updateDisplay(const QString &btn)
 		return;
 	}
 
-	QStringList ops = {"÷", "×", "-", "+"};
+    QStringList ops = {"÷", "×", "+", "-"};
 
 	// Calculate the answer
 	if (btn == "=")


### PR DESCRIPTION
The `ops` object gets joined and put between square brackets (ex: [÷×+-]). The problem is `-` is used to identify ranges and when placed between characters (ex: [÷×-+]) rather than at the start or end of a character class (ex: [÷×+-]) it will either produce an error or be treated as the range indicator and not as the literal `-` character. The fix is simply to ensure the `-` is at the start or end of this object structure.